### PR TITLE
Add fullscreen lyrics functionality

### DIFF
--- a/src/web/styling.ts
+++ b/src/web/styling.ts
@@ -18,6 +18,10 @@ const generateStyles = () => `
     text-align: ${options.lyrics_align};
     line-height: 1.5;
   }
+  ${isStylingActive() === '/*' ? '*/' : ''}
+  .npv-lyrics__content--full-screen {
+    height: 70vh !important;
+  }
 `.trim();
 
 const styleElement = document.createElement('style');


### PR DESCRIPTION
Spotify Premium has a fullscreen feature and it can be used to display lyrics. I made it work for Moegi here.

I have added code to `init.ts` which updates the fullscreen lyrics with the translation and romanization obtained in the non-fullscreen lyrics. I could easily do that because the non-fullscreen lyrics stay in the DOM while the user is in fullscreen.

I have also added some CSS to `styling.ts` to make the fullscreen lyrics taller which is useful because obviously less lines can be displayed when you turn on romanization and/or translation.

I have tested that the fullscreen lyrics work when going in and out of fullscreen, and when songs change. One thing that does not work is going to fullscreen first and only then opening the lyrics, as this would require the extension to work on song URLs and not just `https://open.spotify.com/lyrics`.

<img width="1680" alt="Moegi showing fullscreen lyrics" src="https://github.com/user-attachments/assets/7be5b5b2-6022-4a4a-a9cc-efa86aeab529">
