### PR TITLE
Add translation providers and DeepL provider

### DIFF
--- a/components/options/Translation.tsx
+++ b/components/options/Translation.tsx
@@ -1,7 +1,8 @@
+import { SUPPORTED_LANGUAGES } from '@deeplx/core'
 import { DeepSignal } from 'deepsignal'
-import { languages } from 'google-translate-api-x'
+import { languages as GOOGLE_LANGUAGES } from 'google-translate-api-x'
 import Container from '@/components/Container'
-import Select from '@/components/Select'
+import Select, { SelectProps } from '@/components/Select'
 import Slider from '@/components/Slider'
 import { TranslationOptions } from '@/utils/options'
 
@@ -9,17 +10,37 @@ interface TranslationOptionsProps {
   signal: DeepSignal<TranslationOptions>
 }
 
-const options: { text: string, value: string }[] = Object.entries(languages)
-  .map(([ value, text ]) => ({ text, value }))
-  .filter((el) => el.value !== 'auto')
+const languages: Record<TranslationOptions['provider'], SelectProps<string>['options']> = {
+  google: Object.entries(GOOGLE_LANGUAGES)
+    .map(([ value, text ]) => ({ text, value }))
+    .filter((el) => el.value !== 'auto'),
+
+  deepl: (SUPPORTED_LANGUAGES)
+    .map(({ code, language }) => ({ text: language, value: code.toLowerCase() }))
+}
 
 export default function TranslationOption({ signal }: TranslationOptionsProps) {
   return (
     <Container label="Translation" signal={signal}>
       <Select
+        label="Provider"
+        signal={signal.$provider}
+        options={[
+          { text: 'Google', value: 'google' },
+          { text: 'DeepL', value: 'deepl' },
+        ]}
+      />
+      { signal.provider === 'deepl' &&
+        <Select
+          label="From"
+          signal={signal.$from}
+          options={languages['deepl']}
+        />
+      }
+      <Select
         label="Target"
         signal={signal.$target}
-        options={options}
+        options={languages[signal.provider ?? 'google']}
       />
       <Slider
         label="Font Size"

--- a/entrypoints/background/translate.ts
+++ b/entrypoints/background/translate.ts
@@ -1,27 +1,48 @@
 import { storage } from '#imports'
 import { translate } from 'google-translate-api-x'
 import { Background } from '@/utils/messaging'
+import { SourceLanguage, TargetLanguage, translate as deepl } from '@deeplx/core'
 
 type TranslationCache = Record<string, string>
 
 Background.onMessage('translate', async ({ data }) => {
-  const to = data.to ?? 'auto'
-  const title = data.title + '.' + to
+  const to = data.to ?? 'en'
+  const provider = data.provider ?? 'google'
+  const from = provider === 'deepl' ? (data.from ?? 'en'): 'auto'
+  const key = `${data.title}.${to}.${provider}`
   const cache = await storage.getItem<TranslationCache>('session:translations') || {}
 
-  if (title in cache) return cache[title]
+  // Skip cache if title somehow is empty
+  if (data.title && key in cache) return cache[key]
 
+  // TODO: catch unsupported language code?
   try {
-    const translation = await translate(data.text, {
-      to,
-      from: data.from ?? 'auto',
-      rejectOnPartialFail: false,
-    })
+    let translated: string
 
-    cache[title] = translation.text
+    if (provider === 'deepl') {
+      const translation = await deepl(
+        data.text,
+        to as TargetLanguage,
+        from as SourceLanguage,
+        false,
+      )
+
+      translated = translation
+    } else {
+      const translation = await translate(data.text, {
+        to,
+        from,
+        rejectOnPartialFail: false,
+      })
+
+      translated = translation.text
+    }
+
+    // Sometimes there's newlines i think
+    cache[key] = translated.trim()
     storage.setItem('session:translations', cache)
 
-    return cache[title]
+    return cache[key]
   } catch (error) {
     console.error(error)
     return ''

--- a/entrypoints/lyrics.content/translation.ts
+++ b/entrypoints/lyrics.content/translation.ts
@@ -23,6 +23,8 @@ export default async function lyricsTranslation(data: TranslationOptions): Promi
     text,
     title,
     to: data.target,
+    from: data.from,
+    provider: data.provider,
   })
 
   if (!translated.length) {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
       "dtrace-provider",
       "esbuild",
       "spawn-sync"
-    ]
+    ],
+    "patchedDependencies": {
+      "@deeplx/core": "patches/@deeplx__core.patch"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "postinstall": "wxt prepare"
   },
   "dependencies": {
+    "@deeplx/core": "^0.1.3",
     "@fontsource/quicksand": "^5.2.7",
     "@preact/signals": "^1.3.2",
     "@romanize/korean": "^0.1.3",

--- a/patches/@deeplx__core.patch
+++ b/patches/@deeplx__core.patch
@@ -1,0 +1,42 @@
+diff --git a/lib/translate.js b/lib/translate.js
+index 4e1cc0df623fe2f4821fd9643ede2da3b386bcf2..b0b66e795b26b9f1eeb2c45477c2f77f7c2ca435 100644
+--- a/lib/translate.js
++++ b/lib/translate.js
+@@ -1,5 +1,5 @@
+ import { createProxy } from 'node-fetch-native/proxy';
+-import { detectLang } from 'whatlang-node';
++// import { detectLang } from 'whatlang-node';
+ import { xfetch } from 'x-fetch';
+ import { API_URL, COMMON_HEADERS, HTTP_STATUS_NOT_FOUND, HTTP_STATUS_OK, HTTP_STATUS_SERVICE_UNAVAILABLE, } from "./constants.js";
+ import { abbreviateLanguage, formatPostString, getICount, getRandomNumber, getTimeStamp, } from "./utils.js";
+@@ -13,7 +13,16 @@ const makeRequest = async (postData, proxyUrl, dlSession) => {
+         ...createProxy({ url: proxyUrl }),
+     });
+ };
+-const splitAndProcess = (text) => text.split('\n').map(line => (line.trim() === '' ? '\n' : line));
++// chunks the text into multiple lines per request instead of 1 (too slow!)
++const textChunks = 6;
++const splitAndProcess = (text) => {
++    const lines = text.split('\n');
++    const chunks = [];
++    for (let i = 0; i < lines.length; i += textChunks) {
++        chunks.push(lines.slice(i, i + textChunks).join('\n'));
++    }
++    return chunks;
++};
+ export const translateByDeepLX = async (sourceLang, targetLang, text, formal, tagHandling = 'plaintext', proxyUrl, dlSession) => {
+     if (!text) {
+         return { code: HTTP_STATUS_NOT_FOUND, message: 'No text to translate' };
+@@ -28,7 +37,11 @@ export const translateByDeepLX = async (sourceLang, targetLang, text, formal, ta
+             continue;
+         }
+         if (!sourceLang || sourceLang === 'auto') {
+-            sourceLang = detectLang(part, true);
++            // sourceLang = detectLang(part, true);
++            return {
++              code: HTTP_STATUS_SERVICE_UNAVAILABLE,
++              message: 'LANGUAGE NOT SUPPORTED',
++            }
+         }
+         const sourceLangCode = abbreviateLanguage(sourceLang) ??
+             sourceLang.toUpperCase();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@deeplx/core':
+        specifier: ^0.1.3
+        version: 0.1.3
       '@fontsource/quicksand':
         specifier: ^5.2.7
         version: 5.2.7
@@ -212,6 +215,10 @@ packages:
 
   '@crxjs/vite-plugin@2.0.0-beta.26':
     resolution: {integrity: sha512-fZiSeOB4LOwq3cLIwHJnJ4x/duBU/Gkn3JKF7b7mZIRAXtu1waorJ6QaH7qoZPcN5LzyA3J+/t3Kuwa/oo8XNg==}
+
+  '@deeplx/core@0.1.3':
+    resolution: {integrity: sha512-PUo+4V/3eT2hVWhr8xpMg4BksEl26V5dw19zhSgaapMstcPSEtiqmGdO77MvYa3AN+pjaP6WYf2JJBMU+pXsBw==}
+    engines: {node: ^12.20 || ^14.18.0 || >=16.0.0}
 
   '@devicefarmer/adbkit-logcat@2.1.3':
     resolution: {integrity: sha512-yeaGFjNBc/6+svbDeul1tNHtNChw6h8pSHAt5D+JsedUrMTN7tla7B15WLDyekxsuS2XlZHRxpuC6m92wiwCNw==}
@@ -2657,6 +2664,88 @@ packages:
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
+  whatlang-node-android-arm-eabi@0.1.0:
+    resolution: {integrity: sha512-cib4KyAkpj6kvbNSiVx3X0p16Vwhpv3dwC+G2qNGrdvnOdO8jJhZ4vcG4Vzm1FhqRX9FB8z9rA5ink7t8l1hRg==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  whatlang-node-android-arm64@0.1.0:
+    resolution: {integrity: sha512-dnjsG4KlDRNZu3KeU9aqTQin3WoxkFsJBepGZFCAYjvkzFxe/YX9lrhcTJF6HuaxerDHmj2i3i/yJ1WCUExEIQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  whatlang-node-darwin-arm64@0.1.0:
+    resolution: {integrity: sha512-CyYw6ro09ydAfw9v+p+VFKtQDwm4E4vmr+hYJnkDD2Pxf6MlFnQpa3udJrfU8n7JOy4G6q0SFVVcNBEWWmeDGA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  whatlang-node-darwin-x64@0.1.0:
+    resolution: {integrity: sha512-7wELSpCG8HF8t7CT5D04ApoiEY89dx7MCoCdGjtxCxORIYhqFfL4vd8UPfkwjgmM/bCK9e569XKThfE8u/mjiQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  whatlang-node-freebsd-x64@0.1.0:
+    resolution: {integrity: sha512-xO4FaC6lhlbVwtl8N7blsdFofEjplV6PbsIFN4YSNHU97ZrYUG0T/L3J/RLQUsSDFGhF4fFCHZfRPxnuN+ramQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  whatlang-node-linux-arm-gnueabihf@0.1.0:
+    resolution: {integrity: sha512-R1bKVF05i1FXJ7CY+1HGH3y5FQkQFiN9kUdytgDvjaBAPfY9YEFQZ/zNkpv0CAe6OQolr8zXGSCWNoBfFDxZkA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  whatlang-node-linux-arm64-gnu@0.1.0:
+    resolution: {integrity: sha512-7/jAlxgf7nuHg/CO3AxjsdTFwxIHD8MJoRZN0uby3rq4Je9TkYNTz5Y0YGwyV9TcIrglVX/LVaU+Shyc50nuhw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  whatlang-node-linux-arm64-musl@0.1.0:
+    resolution: {integrity: sha512-c8FwWXshHpLGxrHI+KyQEGcPUE6bbm4VWtnDyoVn4i/LPuJUm447sSaG98FsuRBP6sx0u+1RzSr0WxQyo6ZnMQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  whatlang-node-linux-x64-gnu@0.1.0:
+    resolution: {integrity: sha512-BUq4YM7fN3zj/OSNoifmcW6IeYpA3MNj+E0NOI16pUhgMLba0LWCTBHMAhqDYpdNFlQmMviu+PzTtJJJG9yxOw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  whatlang-node-linux-x64-musl@0.1.0:
+    resolution: {integrity: sha512-isvGfVljIMGlCUtf7fwlFyx/+QCn+YbmrDw7xiPwrFO7o/Iw4am/G70vpDQr6b264iOW2pPf9ZrmDLY+EXYzgA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  whatlang-node-win32-arm64-msvc@0.1.0:
+    resolution: {integrity: sha512-SGenJFMZY56c2nz03NZVKn27hwYG/cv5unoSBl5/JnULg3DpxwG16e8ijoaIHFUakC87BcpyV1aj7NG5JDG5vw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  whatlang-node-win32-ia32-msvc@0.1.0:
+    resolution: {integrity: sha512-2VNisaNXzO06r8FCu6Som7h9uRtqHw6kLkdifTHfAXRqHCPa8JTUVUTAYo+fI4LvSR5s0oCb8OEj5cPeidUFAA==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  whatlang-node-win32-x64-msvc@0.1.0:
+    resolution: {integrity: sha512-IHrPCWah7VqU6myPwZd711R+2py+h33uwOIzclvxYvgVxbDWI4PrY+PmA0e6eEboYL6EUB/t96vAZVUEDaqhxw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  whatlang-node@0.1.0:
+    resolution: {integrity: sha512-KPfuaaKNE9KqdwH57MVhX7Vw1P6WG6quTqcO5WVu67iNuT6qtL0di75yDYCVvGDMFQ+88hQhrymbKTeVwEZFXg==}
+    engines: {node: '>= 10'}
+
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
@@ -2713,6 +2802,10 @@ packages:
   wxt@0.20.6:
     resolution: {integrity: sha512-CdExyv2yWfpmPWFjhrKBA+nUSHOTRpRKqScod66AaLpMQ0famZ18tM0+4a9m7oX4Pts1XZH4nw79XQp06QsC2Q==}
     hasBin: true
+
+  x-fetch@0.2.6:
+    resolution: {integrity: sha512-yHne8a291wWzF/rwCB51kuE4efMMGlCiK1I95W4IOeY7TWESltuNgK4rpw3ukdJXEYQrVcwdypZ/ULT6e6/CfA==}
+    engines: {node: '>=14.0.0'}
 
   xdg-basedir@5.1.0:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
@@ -2939,6 +3032,12 @@ snapshots:
       rxjs: 7.5.7
     transitivePeerDependencies:
       - supports-color
+
+  '@deeplx/core@0.1.3':
+    dependencies:
+      node-fetch-native: 1.6.6
+      whatlang-node: 0.1.0
+      x-fetch: 0.2.6
 
   '@devicefarmer/adbkit-logcat@2.1.3': {}
 
@@ -5379,6 +5478,61 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
+  whatlang-node-android-arm-eabi@0.1.0:
+    optional: true
+
+  whatlang-node-android-arm64@0.1.0:
+    optional: true
+
+  whatlang-node-darwin-arm64@0.1.0:
+    optional: true
+
+  whatlang-node-darwin-x64@0.1.0:
+    optional: true
+
+  whatlang-node-freebsd-x64@0.1.0:
+    optional: true
+
+  whatlang-node-linux-arm-gnueabihf@0.1.0:
+    optional: true
+
+  whatlang-node-linux-arm64-gnu@0.1.0:
+    optional: true
+
+  whatlang-node-linux-arm64-musl@0.1.0:
+    optional: true
+
+  whatlang-node-linux-x64-gnu@0.1.0:
+    optional: true
+
+  whatlang-node-linux-x64-musl@0.1.0:
+    optional: true
+
+  whatlang-node-win32-arm64-msvc@0.1.0:
+    optional: true
+
+  whatlang-node-win32-ia32-msvc@0.1.0:
+    optional: true
+
+  whatlang-node-win32-x64-msvc@0.1.0:
+    optional: true
+
+  whatlang-node@0.1.0:
+    optionalDependencies:
+      whatlang-node-android-arm-eabi: 0.1.0
+      whatlang-node-android-arm64: 0.1.0
+      whatlang-node-darwin-arm64: 0.1.0
+      whatlang-node-darwin-x64: 0.1.0
+      whatlang-node-freebsd-x64: 0.1.0
+      whatlang-node-linux-arm-gnueabihf: 0.1.0
+      whatlang-node-linux-arm64-gnu: 0.1.0
+      whatlang-node-linux-arm64-musl: 0.1.0
+      whatlang-node-linux-x64-gnu: 0.1.0
+      whatlang-node-linux-x64-musl: 0.1.0
+      whatlang-node-win32-arm64-msvc: 0.1.0
+      whatlang-node-win32-ia32-msvc: 0.1.0
+      whatlang-node-win32-x64-msvc: 0.1.0
+
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
@@ -5483,6 +5637,8 @@ snapshots:
       - tsx
       - utf-8-validate
       - yaml
+
+  x-fetch@0.2.6: {}
 
   xdg-basedir@5.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,13 +4,18 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@deeplx/core':
+    hash: 63f958d5a991b9195dd4aa0f16ee7f3fa432d8d43fd4067f7868680497e483bc
+    path: patches/@deeplx__core.patch
+
 importers:
 
   .:
     dependencies:
       '@deeplx/core':
         specifier: ^0.1.3
-        version: 0.1.3
+        version: 0.1.3(patch_hash=63f958d5a991b9195dd4aa0f16ee7f3fa432d8d43fd4067f7868680497e483bc)
       '@fontsource/quicksand':
         specifier: ^5.2.7
         version: 5.2.7
@@ -3033,7 +3038,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@deeplx/core@0.1.3':
+  '@deeplx/core@0.1.3(patch_hash=63f958d5a991b9195dd4aa0f16ee7f3fa432d8d43fd4067f7868680497e483bc)':
     dependencies:
       node-fetch-native: 1.6.6
       whatlang-node: 0.1.0

--- a/utils/messaging.ts
+++ b/utils/messaging.ts
@@ -1,6 +1,6 @@
 import { defineExtensionMessaging } from '@webext-core/messaging'
 import { defineCustomEventMessaging } from '@webext-core/messaging/page'
-import { MoegiOptions } from './options'
+import { MoegiOptions, TranslationOptions } from './options'
 import { DeepKeys } from './deep-keys'
 
 export interface ToastMessage {
@@ -13,6 +13,7 @@ export interface TranslateMessage {
   text: string
   from?: string
   to: string
+  provider?: TranslationOptions['provider']
 }
 
 export interface OptionsMessage {

--- a/utils/options.ts
+++ b/utils/options.ts
@@ -26,7 +26,9 @@ export interface ColorOptions {
 
 export interface TranslationOptions {
   enabled: boolean
+  provider: 'google' | 'deepl'
   size: number
+  from: string
   target: string // TODO: import language from google-translate-api-x?
 }
 
@@ -78,8 +80,10 @@ export const moegiDefaultOptions: MoegiOptions = {
   },
   translation: {
     enabled: false,
+    provider: 'google',
     size: 1,
-    target: 'auto',
+    from: 'en',
+    target: 'en',
   },
   romanization: {
     enabled: false,

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,7 +5,10 @@ import { defineConfig } from 'wxt'
 export default defineConfig({
   manifest: {
     permissions: ['activeTab', 'declarativeContent', 'storage'],
-    host_permissions: ['https://translate.google.com/*'],
+    host_permissions: [
+      'https://translate.google.com/*',
+      'https://www2.deepl.com/*'
+    ],
     // TODO: better security mybe
     externally_connectable: {
       ids: ['*'],


### PR DESCRIPTION
DeepL API has crazy rate limits and apparently translations are automatically transformed into a single line, so using newline as lyric separator won't work.

---

*Generated by Copilot*

This pull request introduces support for the DeepL translation provider alongside Google Translate, enhancing translation capabilities across the application. Key changes include integration of DeepL's API, updates to translation-related components and utilities, and modifications to package dependencies and configurations.

### Integration of DeepL Translation Provider:
* `components/options/Translation.tsx`: Added support for DeepL as a translation provider, including provider-specific language options and UI adjustments for selecting translation providers.
* `entrypoints/background/translate.ts`: Implemented logic for handling translations via DeepL's API, including fallback mechanisms and caching improvements.

### Updates to Translation Utilities:
* `utils/messaging.ts`: Extended the `TranslateMessage` interface to include the `provider` field for specifying translation providers.
* `utils/options.ts`: Updated `TranslationOptions` to include `provider` and `from` fields, with default values set to Google Translate and English respectively.

### Dependency and Configuration Changes:
* `package.json`: Added `@deeplx/core` as a dependency and patched it for improved performance and compatibility.
* `pnpm-lock.yaml`: Updated lockfile to reflect the addition of `@deeplx/core` and its patched dependencies, including optional dependencies for language detection modules.

### Permissions Update:
* `wxt.config.ts`: Extended host permissions to include DeepL's domain for API access.